### PR TITLE
Refactor: Simplified wallet connect/disconnect process

### DIFF
--- a/packages/client/src/components/shared/Navbar.tsx
+++ b/packages/client/src/components/shared/Navbar.tsx
@@ -1,15 +1,15 @@
-import React from 'react';
-import { motion } from 'framer-motion';
-import useWalletConnect from '../../hooks/useWalletConnect';
-import useAddressFormatter from '../../hooks/useAddressFormatter';
+import React from "react";
+import { motion } from "framer-motion";
+import useWalletConnect from "../../hooks/useWalletConnect";
+import useAddressFormatter from "../../hooks/useAddressFormatter";
 
 interface NavbarProps {
   onBackClick: () => void;
 }
 
-
 const Navbar: React.FC<NavbarProps> = ({ onBackClick }) => {
-  const { handleConnect, handleDisconnect, address, isConnected } = useWalletConnect();
+  const { handleConnect, handleDisconnect, address, isConnected } =
+    useWalletConnect();
   const { formatAddress } = useAddressFormatter();
   const ButtonHoverAnimation = {
     scale: 1.05,
@@ -34,12 +34,13 @@ const Navbar: React.FC<NavbarProps> = ({ onBackClick }) => {
 
       <div className="text-white pr-10 flex gap-5">
         {isConnected ? (
-          <div>
-            <div className="text-2xl">Connected: {formatAddress(address)}</div>
-            <button className="text-2xl text-end" onClick={handleDisconnect}>Disconnect</button>
-          </div>
+          <button className="text-4xl" onClick={handleDisconnect}>
+            {formatAddress(address)}
+          </button>
         ) : (
-          <button className="text-4xl" onClick={handleConnect}>Connect Wallet</button>
+          <button className="text-4xl" onClick={handleConnect}>
+            Connect Wallet
+          </button>
         )}
         <div>
           <img src="/images/setting.png" alt="Settings" />
@@ -47,6 +48,6 @@ const Navbar: React.FC<NavbarProps> = ({ onBackClick }) => {
       </div>
     </div>
   );
-}
+};
 
 export default Navbar;


### PR DESCRIPTION
### Issue:
https://github.com/BladeDaoGames/loot-royale-mud/issues/11

### Summary:
Refactored the UI/UX for connecting and disconnecting on the page by removing the dedicated 'Disconnect' button and displaying only the truncated user address. Now, users can simply click on their address to disconnect, streamlining the process and enhancing the overall user experience.

Test:
1. Ensure that user can connect wallet 
![image](https://github.com/BladeDaoGames/loot-royale-mud/assets/148677668/01f3abf7-d7bf-4f0f-9892-e0cb4d9c3aa1)
2. Ensure user can disconnect wallet when clicked again
![image](https://github.com/BladeDaoGames/loot-royale-mud/assets/148677668/113fdbfc-7ecd-4a9b-8a31-fc223b8a121d)
