### PR TITLE
feat: added blinking waiting borders and darkening blocked card

### DIFF
--- a/packages/client/src/components/index.ts
+++ b/packages/client/src/components/index.ts
@@ -11,6 +11,8 @@ import InGameLoading from "./inGame/inGameLoading";
 import InGameInfo from "./inGame/inGameInfo";
 import InGameRanking from "./inGame/inGameRanking";
 import InGameChat from "./inGame/inGameChat";
+import WaitingPlayerCard from "./waitingRoom/waitingPlayerCard";
+import WaitingCharacterCard from "./waitingRoom/waitingCharacerSelection";
 
 export {
   Button,
@@ -26,4 +28,6 @@ export {
   InGameInfo,
   InGameRanking,
   InGameChat,
+  WaitingPlayerCard,
+  WaitingCharacterCard
 };

--- a/packages/client/src/components/waitingRoom/waitingCharacerSelection.tsx
+++ b/packages/client/src/components/waitingRoom/waitingCharacerSelection.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+
+interface CharacterCardProps {
+  imageName: string;
+  title: string;
+  subtitle: string;
+  isOwner?: boolean;
+}
+
+const WaitingCharacterCard = ({ imageName, title, subtitle, isOwner }: CharacterCardProps) => {
+  const ownerOverlay = isOwner ? (
+    <>
+      <img
+        className="absolute top-0 left-0 -mt-1 -ml-1"
+        src="/images/owner_tag.png"
+        alt="owner_tag"
+      />
+      <div
+        className="absolute top-2 left-0 mt-2 ml-2 z-20 text-white text-4xl"
+        style={{ transform: "rotate(312deg)" }}
+      >
+        Owner
+      </div>
+    </>
+  ) : null;
+
+  return (
+    <div className="relative flex flex-col justify-center items-center border border-beige-100 rounded-md shadow-right-bottom-medium w-1/3 h-1/3 bg-beige-200/2">
+      {ownerOverlay}
+      <img className="py-4 z-1" src={`/images/${imageName}.png`} alt={title} />
+      <div className="flex justify-between items-center w-9/12 -mt-2">
+        <div className="text-xl text-white bg-beige-100 rounded-md px-4 h-6">{subtitle}</div>
+        <div className="text-4xl text-beige-100">{title}</div>
+      </div>
+    </div>
+  );
+};
+
+export default WaitingCharacterCard;

--- a/packages/client/src/components/waitingRoom/waitingPlayerCard.css
+++ b/packages/client/src/components/waitingRoom/waitingPlayerCard.css
@@ -1,0 +1,13 @@
+@keyframes blink {
+  0%,
+  100% {
+    border-color: transparent;
+  }
+  50% {
+    border-color: #9b8a70;
+  }
+}
+
+.blinking-border {
+  animation: blink 1s linear infinite;
+}

--- a/packages/client/src/components/waitingRoom/waitingPlayerCard.tsx
+++ b/packages/client/src/components/waitingRoom/waitingPlayerCard.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { BiUserPlus } from "react-icons/bi";
+import { ImCross } from "react-icons/im";
+import { PlayerCardType } from "../../constants/components/waiting.constants";
+import "./waitingPlayerCard.css"; 
+
+interface PlayerCardProps {
+  type: PlayerCardType;
+  title?: string;
+}
+
+const WaitingPlayerCard = ({ type, title }: PlayerCardProps) => {
+  const renderCardContent = () => {
+    switch (type) {
+      case PlayerCardType.INVITE:
+        return (
+          <BiUserPlus
+            className="text-beige-100"
+            style={{ width: "100px", height: "100px" }}
+          />
+        );
+      case PlayerCardType.BLOCKED:
+        return (
+          <ImCross
+            className="text-beige-100"
+            style={{ width: "100px", height: "100px" }}
+          />
+        );
+      default:
+        return null;
+    }
+  };
+  const borderClass = type === PlayerCardType.INVITE ? "blinking-border" : "";
+  const cardStyle = type === PlayerCardType.BLOCKED
+    ? "bg-slate-950 bg-opacity-30 text-gray-400" // Darkening effect for blocked cards
+    : "bg-beige-200/2"; // Normal style for other cards
+
+  return (
+    <div
+    className={`relative flex flex-col justify-center items-center border border-beige-100 rounded-md shadow-right-bottom-medium w-1/3 h-1/3 ${cardStyle} ${borderClass}`}
+    >
+      <div
+        className={`my-4 flex justify-center items-center bg-white-beige-100/10 border-2 border-dotted border-beige-100 rounded-md bg`}
+        style={{ width: "216px", height: "171px" }}
+      >
+        {renderCardContent()}
+      </div>
+      {title && (
+        <div className="flex justify-center items-center w-9/12 -mt-2 text-4xl text-beige-100">
+          {title}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default WaitingPlayerCard;

--- a/packages/client/src/components/waitingRoom/waitingPlayerSelection.tsx
+++ b/packages/client/src/components/waitingRoom/waitingPlayerSelection.tsx
@@ -1,102 +1,55 @@
-import React, { useState } from "react";
-import { Button } from "..";
-import { BiUserPlus } from "react-icons/bi";
-import { ImCross } from "react-icons/im";
+import React from "react";
+import { WaitingCharacterCard, WaitingPlayerCard } from "..";
+import { PlayerCardType } from "../../constants/components/waiting.constants";
 
 const MapPlayerSelection = () => {
+  const kleeCustomOverlay = (
+    <>
+      <img
+        className="absolute top-0 left-0 -mt-1 -ml-1"
+        src="/images/owner_tag.png"
+        alt="owner_tag"
+      />
+      <div
+        className="absolute top-2 left-0 mt-2 ml-2 z-20 text-white text-4xl"
+        style={{ transform: "rotate(312deg)" }}
+      >
+        Owner
+      </div>
+    </>
+  );
   return (
     <div className="p-3 max-h-[600px]">
       {/**Row 1 for player cards */}
       <div className="flex gap-4">
         {/**Klee */}
-        <div className="relative flex flex-col justify-center items-center border border-beige-100 rounded-md shadow-right-bottom-medium w-1/3 h-1/3 bg-beige-200/2">
-          <img className="py-4 z-1" src="/images/klee.png" alt="klee" />
-          <img
-            className="absolute top-0 left-0 -mt-1 -ml-1"
-            src="/images/owner_tag.png"
-            alt="owner_tag"
-          />
-          <div
-            className="absolute top-2 left-0 mt-2 ml-2 z-20 text-white text-4xl"
-            style={{ transform: "rotate(312deg)" }}
-          >
-            Owner
-          </div>
-          <div className="flex justify-between items-center w-9/12 -mt-2">
-            <div className="text-xl text-white bg-beige-100 rounded-md px-4 h-6">
-              Staked
-            </div>
-            <div className="text-4xl text-beige-100">Mob User 1</div>
-          </div>
-        </div>
+        <WaitingCharacterCard
+          imageName="klee"
+          title="Mob User 1"
+          subtitle="Staked"
+          isOwner={true}  // Set based on your logic
+        />
         {/**Venti */}
-        <div className="relative flex flex-col justify-center items-center border border-beige-100 rounded-md shadow-right-bottom-medium w-1/3 h-1/3 bg-beige-200/2">
-          <img className="py-4 z-1" src="/images/venti.png" alt="venti" />
-          <div className="flex justify-between items-center w-9/12  -mt-2">
-            <div className="text-xl text-white bg-beige-100 rounded-md px-4 h-6">
-              Staked
-            </div>
-            <div className="text-4xl text-beige-100">Mob User 1</div>
-          </div>
-        </div>
+        <WaitingCharacterCard
+          imageName="venti"
+          title="Mob User 1"
+          subtitle="Staked"
+        />
         {/**Eula */}
-        <div className="relative flex flex-col justify-center items-center border border-beige-100 rounded-md shadow-right-bottom-medium w-1/3 h-1/3 bg-beige-200/2">
-          <img className="py-4 z-1" src="/images/eula.png" alt="eula" />
-          <div className="flex justify-between items-center w-9/12 -mt-2">
-            <div className="text-xl text-white bg-beige-100 rounded-md px-4 h-6">
-              Staked
-            </div>
-            <div className="text-4xl text-beige-100">Mob User 1</div>
-          </div>
-        </div>
+        <WaitingCharacterCard
+          imageName="eula"
+          title="Mob User 1"
+          subtitle="Staked"
+        />
       </div>
       {/**Row 2 for player cards */}
       <div className="flex gap-4 my-4">
         {/**Invite player card 1 */}
-        <div className="relative flex flex-col justify-center items-center border border-beige-100 rounded-md shadow-right-bottom-medium w-1/3 h-1/3 bg-beige-200/2">
-          <div
-            className="my-4 flex justify-center items-center bg-white-beige-300 border-2 border-dotted border-beige-100 rounded-md"
-            style={{ width: "216px", height: "171px" }}
-          >
-            <BiUserPlus
-              className="text-beige-100"
-              style={{ width: "100", height: "100px" }}
-            />
-          </div>
-          <div className="flex justify-center items-center w-9/12 -mt-2 text-4xl text-beige-100">
-            Waiting Player
-          </div>
-        </div>
+        <WaitingPlayerCard type={PlayerCardType.INVITE} title="Waiting Player" />
         {/**Invite Player card 2 */}
-        <div className="relative flex flex-col justify-center items-center border border-beige-100 rounded-md shadow-right-bottom-medium w-1/3 h-1/3 bg-beige-200/2">
-          <div
-            className="my-4 flex justify-center items-center bg-white-beige-300 border-2 border-dotted border-beige-100 rounded-md"
-            style={{ width: "216px", height: "171px" }}
-          >
-            <BiUserPlus
-              className="text-beige-100"
-              style={{ width: "100", height: "100px" }}
-            />
-          </div>
-          <div className="flex justify-center items-center w-9/12 -mt-2 text-4xl text-beige-100">
-            Waiting Player
-          </div>
-        </div>
+        <WaitingPlayerCard type={PlayerCardType.INVITE} title="Waiting Player" />
         {/**Blocked */}
-        <div className="relative flex flex-col justify-center items-center border border-beige-100 rounded-md shadow-right-bottom-medium w-1/3 h-1/3 bg-beige-200/2">
-          <div
-            className="my-4 flex justify-center items-center bg-white-beige-100/10 border-2 border-dotted border-beige-100 rounded-md"
-            style={{ width: "216px", height: "171px" }}
-          >
-            <ImCross
-              className="text-beige-100"
-              style={{ width: "100", height: "100px" }}
-            />
-          </div>
-          <div className="flex justify-center items-center w-9/12 -mt-2 text-4xl text-beige-100">
-            Blocked
-          </div>
-        </div>
+        <WaitingPlayerCard type={PlayerCardType.BLOCKED} title="Blocked" />
       </div>
     </div>
   );

--- a/packages/client/src/constants/components/waiting.constants.ts
+++ b/packages/client/src/constants/components/waiting.constants.ts
@@ -1,0 +1,5 @@
+export enum PlayerCardType {
+    INVITE = "invite",
+    BLOCKED = "blocked",
+  }
+  


### PR DESCRIPTION
### Issue:
https://github.com/BladeDaoGames/loot-royale-mud/issues/15

### Summary:
1. Refactored character cards, such as Klee, Venti, and Eula, into a separate file named` waitingCharacterSelection.tsx.`
2. Refactored player cards, including waiting and blocked players, into a separate file `waitingPlayerCard.tsx.`
3. Added a new CSS file, `waitingPlayerCard.css`, to contain the blinking animation for waiting player cards.
4. Implemented conditional styling in `waitingPlayerCard.tsx` using Tailwind: when a blocked player card is passed in, it appears darkened to indicate that it is blocked; if a waiting player card is passed in, its border blinks to signify that it is awaiting players.

### Reasoning behind storing blinking animation keyframes in css:
Although I have experimented with CSS, Framer Motion, and the Tailwind module for creating the blinking borders, I found CSS to be the most effective method. Since the border blinking effect is quite custom and Tailwind doesn't offer built-in animations to support it directly, we would have to define the animation in tailwind.config.ts. However, adding such specific animations to the Tailwind configuration can be considered bad practice, as it could lead to an overly complex and unwieldy configuration file. As for Framer Motion, it appears to be less suited for continuously rendering blinking objects (as it is computationally expensive to render it with js), lacking the straightforward capability for such persistent animations. Consequently, using plain CSS for this specific case turned out to be the best approach, providing the needed control and efficiency for the blinking border effect