### PR TITLE
Fix: commented out redundant max player bar

### DIFF
--- a/packages/client/src/components/waitingRoom/waitingMapSelection.tsx
+++ b/packages/client/src/components/waitingRoom/waitingMapSelection.tsx
@@ -30,7 +30,7 @@ const MapSelection = ({ onApply }: MapSelectionProps) => {
       </div>
 
       {/* Max player box */}
-      <div className="w-11/12 py-2 border border-beige-100 text-beige-100 text-4xl flex justify-center gap-10 mt-4 rounded-md shadow-right-bottom-medium">
+      {/* <div className="w-11/12 py-2 border border-beige-100 text-beige-100 text-4xl flex justify-center gap-10 mt-4 rounded-md shadow-right-bottom-medium">
         <div>Max Player</div>
         <input
           type="number"
@@ -42,7 +42,7 @@ const MapSelection = ({ onApply }: MapSelectionProps) => {
           onChange={(e) => setMaxPlayers(Number(e.target.value))}
           className="border border-beige-100 text-3xl text-right w-28 bg-white-beige-50"
         />
-      </div>
+      </div> */}
 
       {/* Apply button */}
       <Button


### PR DESCRIPTION
### Issue:
https://github.com/BladeDaoGames/loot-royale-mud/issues/17

### Summary:
Removed the max player bar selection from the map selection interface, as it is currently redundant. Will revisit the functionality in the future.
![image](https://github.com/BladeDaoGames/loot-royale-mud/assets/148677668/c3f22b1b-97c5-4d9a-aedf-8ed05443dd34)

