### PR TITLE
Feat: added owner button and refactored button class

### DIFF
--- a/packages/client/src/components/shared/Button.tsx
+++ b/packages/client/src/components/shared/Button.tsx
@@ -4,27 +4,46 @@ interface ButtonProps {
   onClick: () => void;
   children: React.ReactNode;
   className?: string;
+  disabled?: boolean;
 }
 
-export const Button = ({ onClick, children, className }: ButtonProps) => {
-  const ButtonHoverAnimation = {
-    scale: 1.05,
-    transition: {
-      type: "spring",
-      stiffness: 150,
-    },
+export const Button = ({
+  onClick,
+  children,
+  className = "",
+  disabled = false,
+}: ButtonProps) => {
+  const buttonHoverAnimation = disabled
+    ? undefined  
+    : {
+        scale: 1.05,
+        transition: {
+          type: "spring",
+          stiffness: 150,
+        },
+      };
+
+  const handleClick = () => {
+    if (!disabled) {
+      onClick();
+    }
   };
 
-  const buttonClass = `cursor-pointer ${className}`;
+  const buttonClass = `cursor-pointer ${className} ${disabled ? "opacity-50 cursor-not-allowed" : ""}`;
 
   return (
     <motion.div
-      whileHover={ButtonHoverAnimation}
-      onClick={onClick}
+      whileHover={buttonHoverAnimation}
+      onClick={handleClick}
       className={buttonClass}
+      // the bottom 3 is to deal with accessibility issues
+      role="button"
+      tabIndex={disabled ? -1 : 0}
+      aria-disabled={disabled}
     >
       {children}
     </motion.div>
   );
 };
+
 export default Button;

--- a/packages/client/src/pages/WaitingRoom/WaitingRoom.tsx
+++ b/packages/client/src/pages/WaitingRoom/WaitingRoom.tsx
@@ -40,12 +40,19 @@ const WaitingRoom = () => {
             >
               Exit room
             </Button>
-            <Button onClick={()=>{}} className="flex justify-center gap-4 items-center w-6/12 bg-beige-100 text-white shadow-right-bottom-medium rounded-lg pt-2 mr-6 pb-1">
+            <Button
+              className="flex justify-center items-center w-52 bg-beige-100 text-white shadow-right-bottom-medium rounded-lg pt-2 ml-6"
+              onClick={goToRooms}
+              disabled={true}
+            >
+              Owner start
+            </Button>
+            <Button onClick={()=>{}} className="flex justify-center gap-4 items-center w-4/12 bg-beige-100 text-white shadow-right-bottom-medium rounded-lg pt-2 mr-6 pb-1">
               {" "}
               <div className="text-2xl text-beige-100 bg-white rounded-full w-10 h-10 flex justify-center items-center">
                 <FaEthereum />
               </div>
-              <div className="-mb-1"> Stake 999 Eth to Start Game </div>
+              <div className="-mb-1"> Stake Eth to Start </div>
             </Button>
           </div>
         </div>


### PR DESCRIPTION
### Issue:
https://github.com/BladeDaoGames/loot-royale-mud/issues/19\

### Summary:
This pull request includes the addition of a new feature and the refactoring of an existing button component to accommodate this feature:
1. Owner Start Feature: I've added an "Owner Start" button, enabling only the game owner to initiate the game once all players have staked their ETH.
2. Button Label Update: The button previously labeled "Stake 999 ETH to Start Game" has been renamed to "Stake to Start." This change reduces the button's screen footprint, aligning better with UX-friendly design principles.
3. Button Component Refactoring: The button component has been refactored to include an optional boolean property. When set to true, this property disables the button, rendering it greyed out and non-clickable. This change allows for enhanced flexibility when the button is used in various parent pages/components.

![image](https://github.com/BladeDaoGames/loot-royale-mud/assets/148677668/135afbf6-ddd6-45bc-a9b8-7902fe53d7df)
