### PR TITLE
Feat: added colour differentiation for stake/unstake status

### DIFF
--- a/packages/client/src/components/waitingRoom/waitingCharacerSelection.tsx
+++ b/packages/client/src/components/waitingRoom/waitingCharacerSelection.tsx
@@ -3,11 +3,16 @@ import React from "react";
 interface CharacterCardProps {
   imageName: string;
   title: string;
-  subtitle: string;
   isOwner?: boolean;
+  isStaked?: boolean;
 }
 
-const WaitingCharacterCard = ({ imageName, title, subtitle, isOwner }: CharacterCardProps) => {
+const WaitingCharacterCard = ({
+  imageName,
+  title,
+  isOwner,
+  isStaked = false,
+}: CharacterCardProps) => {
   const ownerOverlay = isOwner ? (
     <>
       <img
@@ -23,13 +28,21 @@ const WaitingCharacterCard = ({ imageName, title, subtitle, isOwner }: Character
       </div>
     </>
   ) : null;
+  const subtitle = isStaked ? "Staked" : "Stake Now";
+  const borderClass = isStaked ? "border-green-500" : "border-beige-100";
+  const subtitleClass = `text-xl text-white ${
+    isStaked ? "bg-green-600" : "bg-orange-600"
+  } rounded-md px-4 h-6`;
 
   return (
-    <div className="relative flex flex-col justify-center items-center border border-beige-100 rounded-md shadow-right-bottom-medium w-1/3 h-1/3 bg-beige-200/2">
+    <div
+      className={`relative flex flex-col justify-center items-center border ${borderClass} rounded-md shadow-right-bottom-medium w-1/3 h-1/3 bg-beige-200/2`}
+    >
       {ownerOverlay}
       <img className="py-4 z-1" src={`/images/${imageName}.png`} alt={title} />
       <div className="flex justify-between items-center w-9/12 -mt-2">
-        <div className="text-xl text-white bg-beige-100 rounded-md px-4 h-6">{subtitle}</div>
+        <div className={subtitleClass}>{subtitle}</div>
+        {/* <div className="text-xl text-white bg-beige-100 rounded-md px-4 h-6">{subtitle}</div> */}
         <div className="text-4xl text-beige-100">{title}</div>
       </div>
     </div>

--- a/packages/client/src/components/waitingRoom/waitingPlayerSelection.tsx
+++ b/packages/client/src/components/waitingRoom/waitingPlayerSelection.tsx
@@ -26,20 +26,18 @@ const MapPlayerSelection = () => {
         <WaitingCharacterCard
           imageName="klee"
           title="Mob User 1"
-          subtitle="Staked"
           isOwner={true}  // Set based on your logic
+          isStaked={true}
         />
         {/**Venti */}
         <WaitingCharacterCard
           imageName="venti"
           title="Mob User 1"
-          subtitle="Staked"
         />
         {/**Eula */}
         <WaitingCharacterCard
           imageName="eula"
           title="Mob User 1"
-          subtitle="Staked"
         />
       </div>
       {/**Row 2 for player cards */}


### PR DESCRIPTION
### Issue:
https://github.com/BladeDaoGames/loot-royale-mud/issues/21

### Summary:
The purpose of this pull request is to introduce color differentiation to indicate the status of player cards. Specifically, when a user has staked, the card will feature a green border. Additionally, the 'Stake' button (or display label) will also have a green background, accompanied by the word 'Staked'. Conversely, if the player has not staked yet, the background will be orange, and the label will read 'Stake Now'.

![image](https://github.com/BladeDaoGames/loot-royale-mud/assets/148677668/52223596-aca0-4e2b-a62b-18cf07b90595)


